### PR TITLE
remove base64 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "generator-core-version": "~3",
     "license": "Apache 2.0",
     "dependencies": {
-        "jquery": "^2.1.1",
-        "base64": "^2.1.0"
+        "jquery": "^2.1.1"
     },
     "devDependencies": {
         "mocha": "^1.20.1",

--- a/svgWriterUtils.js
+++ b/svgWriterUtils.js
@@ -21,8 +21,7 @@
 (function () {
 "use strict";
 
-    var base64 = require("base64").encode,
-        Buffer = require('buffer').Buffer,
+    var Buffer = require('buffer').Buffer,
         guidID = 1,
         svgWriterIDs = require("./svgWriterIDs.js");
 
@@ -326,7 +325,7 @@
 
         this.toBase64 = function (string) {
             var buf = new Buffer(string);
-            return base64(buf);
+            return buf.toString("base64");
         };
 	}
 


### PR DESCRIPTION
Uses node's built-in base64 encoding for Buffer objects instead.
